### PR TITLE
Surajsureshkumar crud functionality for comments on request page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>software.amazon.awssdk</groupId>-->
 <!--            <artifactId>sqs</artifactId>-->
@@ -120,8 +124,16 @@
 <!--            <artifactId>spring-cloud-aws-sqs</artifactId>-->
 <!--            <version>3.2.0-M1</version>-->
 <!--        </dependency>-->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+
 
     </dependencies>
+
+
 
     <build>
         <plugins>
@@ -163,6 +175,24 @@
                         <phase>none</phase>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
 
             <!-- Jacoco Plugin -->

--- a/src/main/java/org/sfa/request/controller/CommentController.java
+++ b/src/main/java/org/sfa/request/controller/CommentController.java
@@ -1,0 +1,68 @@
+package org.sfa.request.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.sfa.request.dto.CommentDTO;
+import org.sfa.request.mapper.CommentMapper;
+import org.sfa.request.response.SaayamResponse;
+import org.sfa.request.service.api.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1.0.0/requests/{requesterId}/{requestId}")
+@RequiredArgsConstructor
+@Tag(name = "Comment", description = "Comment management APIs")
+public class CommentController {
+    private final CommentMapper commentMapper;
+    private final CommentService commentService;
+
+
+    @GetMapping("/comments/{commentId}")
+    public ResponseEntity<SaayamResponse<CommentDTO>> getCommentByRequestId(
+            @PathVariable @NotNull String requestId,
+            @PathVariable @NotNull Long commentId
+    ){
+        SaayamResponse<CommentDTO> response = commentService.getCommentById(requestId, commentId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/comments")
+    public ResponseEntity<SaayamResponse<CommentDTO>> createComment(
+            @PathVariable @NotNull String requestId,
+            @RequestBody @Valid CommentDTO createCommentDTO
+    ) {
+        SaayamResponse<CommentDTO> response =
+                commentService.createComment(
+                        requestId, createCommentDTO.getAuthorName(), createCommentDTO.getCommentText());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<SaayamResponse<CommentDTO>> updateComment(
+            @PathVariable @NotNull String requestId,
+            @PathVariable @NotNull Long commentId,
+            @RequestBody @Valid CommentDTO updateCommentDTO
+    ) {
+        SaayamResponse<CommentDTO> response =
+                commentService.updateComment(requestId, commentId, updateCommentDTO.getCommentText());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<SaayamResponse<Void>> deleteComment(
+            @PathVariable @NotNull Long commentId,
+            @PathVariable @NotNull String requestId
+    ) {
+        commentService.deleteComment(requestId, commentId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/sfa/request/dto/CommentDTO.java
+++ b/src/main/java/org/sfa/request/dto/CommentDTO.java
@@ -1,0 +1,30 @@
+package org.sfa.request.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDTO {
+
+    @NotNull
+    private Long commentId;
+
+    @NotBlank
+    @Size(max = 100, message = "Author name should not exceed 100 characters for an entry")
+    private String authorName;
+
+    @NotBlank
+    @Size(max = 500, message = "Comment text should not exceed 500 characters for one single comment")
+    private String commentText;
+
+    public CommentDTO(String authorName, String commentText) {
+        this.authorName = authorName;
+        this.commentText = commentText;
+    }
+}

--- a/src/main/java/org/sfa/request/exception/types/ResourceNotFoundException.java
+++ b/src/main/java/org/sfa/request/exception/types/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package org.sfa.request.exception.types;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/sfa/request/mapper/CommentMapper.java
+++ b/src/main/java/org/sfa/request/mapper/CommentMapper.java
@@ -1,0 +1,13 @@
+package org.sfa.request.mapper;
+
+import org.mapstruct.Mapper;
+import org.sfa.request.dto.CommentDTO;
+import org.sfa.request.model.entity.Comment;
+
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+    Comment toEntity(CommentDTO commentDto);
+    CommentDTO toDTO(Comment comment);
+
+
+}

--- a/src/main/java/org/sfa/request/model/entity/Comment.java
+++ b/src/main/java/org/sfa/request/model/entity/Comment.java
@@ -1,0 +1,34 @@
+package org.sfa.request.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "comments")
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name= "author_name", nullable = false, columnDefinition = "VARCHAR(255)", length = 100)
+    private String authorName;
+
+    @NotBlank
+    @Size(max = 500)
+    @Column(name= "comment_text", nullable = false, columnDefinition = "VARCHAR(255)", length = 500)
+    private String commentText;
+
+    @ManyToOne
+    @JoinColumn(name = "request_id", nullable = false, foreignKey = @ForeignKey(name = "fk_request_id"))
+    private Request request;
+}

--- a/src/main/java/org/sfa/request/model/entity/Comment.java
+++ b/src/main/java/org/sfa/request/model/entity/Comment.java
@@ -20,12 +20,12 @@ public class Comment {
 
     @NotBlank
     @Size(max = 100)
-    @Column(name= "author_name", nullable = false, columnDefinition = "VARCHAR(255)", length = 100)
+    @Column(name= "author_name", nullable = false, columnDefinition = "VARCHAR(255)")
     private String authorName;
 
     @NotBlank
     @Size(max = 500)
-    @Column(name= "comment_text", nullable = false, columnDefinition = "VARCHAR(255)", length = 500)
+    @Column(name= "comment_text", nullable = false, columnDefinition = "VARCHAR(255)")
     private String commentText;
 
     @ManyToOne

--- a/src/main/java/org/sfa/request/model/entity/Request.java
+++ b/src/main/java/org/sfa/request/model/entity/Request.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 /**
  * ClassName: Request
@@ -81,6 +82,9 @@ public class Request implements Serializable {
             foreignKey = @ForeignKey(name = "fk_request_for_id")
     )
     private RequestFor requestFor;
+
+    @OneToMany(mappedBy = "request", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Comment> comments;
 
     @Column(name = "city_name", columnDefinition = "VARCHAR(255)")
     private String city;

--- a/src/main/java/org/sfa/request/repository/CommentRepository.java
+++ b/src/main/java/org/sfa/request/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package org.sfa.request.repository;
+
+import org.sfa.request.model.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByRequestIdAndCommentId(String requestId, Long commentId);
+}

--- a/src/main/java/org/sfa/request/service/api/CommentService.java
+++ b/src/main/java/org/sfa/request/service/api/CommentService.java
@@ -1,0 +1,20 @@
+package org.sfa.request.service.api;
+
+import org.sfa.request.dto.CommentDTO;
+import org.sfa.request.response.SaayamResponse;
+
+/**
+ * ClassName: CommentService
+ * Package: org.sfa.request.service.api
+ */
+public interface CommentService {
+
+
+    SaayamResponse<CommentDTO> createComment(String requestId, String authorName, String commentText);
+
+    SaayamResponse<CommentDTO> updateComment(String requestId, Long commentId, String commentText);
+
+    SaayamResponse<CommentDTO> deleteComment(String requestId, Long commentId);
+
+    SaayamResponse<CommentDTO> getCommentById(String requestId, Long commentId);
+}

--- a/src/main/java/org/sfa/request/service/impl/CommentServiceImpl.java
+++ b/src/main/java/org/sfa/request/service/impl/CommentServiceImpl.java
@@ -1,0 +1,97 @@
+package org.sfa.request.service.impl;
+
+import org.sfa.request.constant.SaayamStatusCode;
+import org.sfa.request.dto.CommentDTO;
+import org.sfa.request.exception.types.ResourceNotFoundException;
+import org.sfa.request.mapper.CommentMapper;
+import org.sfa.request.model.entity.Comment;
+import org.sfa.request.repository.CommentRepository;
+import org.sfa.request.repository.RequestRepository;
+import org.sfa.request.response.SaayamResponse;
+import org.sfa.request.service.api.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+    private final RequestRepository requestRepository;
+
+    @Autowired
+    public CommentServiceImpl(CommentRepository commentRepository, CommentMapper commentMapper, RequestRepository requestRepository) {
+        this.commentRepository = commentRepository;
+        this.commentMapper = commentMapper;
+        this.requestRepository = requestRepository;
+    }
+
+    @Override
+    public SaayamResponse<CommentDTO> createComment(String requestId, String authorName, String commentText) {
+        boolean requestExistsForComment = requestRepository.existsById(requestId);
+        if(!requestExistsForComment){
+            throw new ResourceNotFoundException("Request with id:" + requestId + "not found.");
+        }
+
+        Comment comment = commentMapper.toEntity(new CommentDTO(authorName, commentText));
+
+        Comment savedCommentForRequest = commentRepository.save(comment);
+
+        CommentDTO commentDTO = commentMapper.toDTO(savedCommentForRequest);
+
+        return SaayamResponse.success(
+                SaayamStatusCode.SUCCESS,
+                "Comment Created Successfully",
+                commentDTO);
+    }
+
+    @Override
+    public SaayamResponse<CommentDTO> updateComment(String requestId, Long commentId, String commentText) {
+
+        Comment commentToBeUpdated = commentRepository.findByRequestIdAndCommentId(requestId, commentId).orElseThrow(() ->
+                new ResourceNotFoundException(
+                        "Comment not found with id:" + commentId
+                        + "does not belong to request with id:" + requestId));
+
+        commentToBeUpdated.setCommentText(commentText);
+
+        Comment updateComment = commentRepository.save(commentToBeUpdated);
+
+        CommentDTO commentDTO = commentMapper.toDTO(updateComment);
+
+        return SaayamResponse.success(
+                SaayamStatusCode.SUCCESS,
+                "Comment Content Updated Successfully",
+                commentDTO);
+    }
+
+    @Override
+    public SaayamResponse<CommentDTO> deleteComment(String requestId, Long commentId) {
+        Comment commentToBeDeleted = commentRepository.findByRequestIdAndCommentId(requestId, commentId).orElseThrow(() ->
+                new ResourceNotFoundException(
+                        "Comment not found with id:" + commentId
+                                + "does not belong to request with id:" + requestId + "and must already be deleted"));
+
+        commentRepository.delete(commentToBeDeleted);
+
+        return SaayamResponse.success(
+                SaayamStatusCode.SUCCESS,
+                "Comment Deleted Successfully",
+                null);
+    }
+
+    @Override
+    public SaayamResponse<CommentDTO> getCommentById(String requestId, Long commentId) {
+        Comment commentToBeUpdated = commentRepository.findByRequestIdAndCommentId(requestId, commentId).orElseThrow(() ->
+                new ResourceNotFoundException(
+                        "Comment not found with id:" + commentId
+                                + "does not belong to request with id:" + requestId));
+
+        CommentDTO commentDTO = commentMapper.toDTO(commentToBeUpdated);
+
+        return SaayamResponse.success(
+                SaayamStatusCode.SUCCESS,
+                "Comment Retrieved Successfully",
+                commentDTO);
+    }
+}

--- a/src/test/java/org/sfa/request/controller/CommentControllerTest.java
+++ b/src/test/java/org/sfa/request/controller/CommentControllerTest.java
@@ -1,0 +1,141 @@
+package org.sfa.request.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sfa.request.constant.SaayamStatusCode;
+import org.sfa.request.dto.CommentDTO;
+import org.sfa.request.mapper.CommentMapper;
+import org.sfa.request.repository.CommentRepository;
+import org.sfa.request.response.SaayamResponse;
+import org.sfa.request.service.api.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CommentControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private CommentController commentController;
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public CommentService commentService() {
+            return Mockito.mock(CommentService.class);
+        }
+
+        @Bean
+        public CommentMapper commentMapper() {
+            return Mockito.mock(CommentMapper.class);
+        }
+    }
+
+    @Test
+    void createComment() throws Exception {
+        CommentDTO commentDTO = new CommentDTO();
+
+        commentDTO.setAuthorName("Test User");
+        commentDTO.setCommentText("Test comment");
+        String requestId = "test123";
+        String requesterId = "tester123";
+
+        SaayamResponse<CommentDTO> response =
+                SaayamResponse.success(SaayamStatusCode.SUCCESS, " Test Comment Created Successfully", commentDTO);
+
+        Mockito.when(commentService.createComment(eq(requestId), anyString(), anyString()))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/api/v1.0.0/requests/{requesterId}/{requestId}/comments",
+                        requesterId, requestId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Comment Created Successfully"))
+                .andExpect(jsonPath("$.data.commentText").value("Test comment"));
+    }
+
+    @Test
+    void getCommentByRequestId() throws Exception {
+        String requestId = "test123";
+        String requesterId = "tester123";
+
+        CommentDTO commentDTO = new CommentDTO();
+
+        commentDTO.setCommentId(1L);
+        commentDTO.setCommentText("Test comment");
+
+        SaayamResponse<CommentDTO> response =
+                SaayamResponse.success(SaayamStatusCode.SUCCESS, "Comment Fetched Successfully", commentDTO);
+
+        Mockito.when(commentService.getCommentById(eq(requestId), eq(1L)))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/v1.0.0/requests/{requesterId}/{requestId}/comments/{commentId}",
+                        requesterId, requestId, 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Comment Fetched Successfully"))
+                .andExpect(jsonPath("$.data.commentText").value("Test comment"))
+                .andExpect(jsonPath("$.data.commentId").value(1));
+    }
+
+    @Test
+    void updateComment() throws Exception {
+        String requestId = "test123";
+        String requesterId = "tester123";
+
+        CommentDTO commentDTO = new CommentDTO();
+        commentDTO.setCommentText("Test comment update");
+        commentDTO.setCommentId(1L);
+
+        SaayamResponse<CommentDTO> response =
+                SaayamResponse.success(SaayamStatusCode.SUCCESS, "Comment Updated Successfully", commentDTO);
+
+        Mockito.when(commentService.updateComment(eq(requestId), eq(1L), eq("Test comment update")))
+                .thenReturn(response);
+
+        mockMvc.perform(put("/api/v1.0.0/requests/{requesterId}/{requestId}/comments/{commentId}",
+                        requesterId, requestId, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Comment Updated Successfully"))
+                .andExpect(jsonPath("$.data.commentText").value("Test comment update"));
+    }
+
+    @Test
+    void deleteComment() throws Exception {
+        String requestId = "test123";
+        String requesterId = "tester123";
+        Long commentId = 1L;
+
+        Mockito.when(commentService.deleteComment(anyString(), anyLong()))
+                .thenReturn(SaayamResponse.success(SaayamStatusCode.SUCCESS, "Deleted successfully", new CommentDTO()));
+
+        mockMvc.perform(delete("/api/v1.0.0/requests/{requesterId}/{requestId}/comments/{commentId}",
+                        requesterId, requestId, commentId))
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
Implemented full CRUD functionality for managing comments on the request page. This includes:
- Creating a new comment
- Retrieving a comment by ID
- Updating an existing comment
- Deleting a comment

Added unit and integration tests for `CommentController` to validate all endpoints.

## Files Added/Changed

- `CommentController.java`
- `CommentDTO.java`
- `CommentService.java` (interface)
- `CommentServiceImpl.java`
- `CommentRepository.java`
- `CommentControllerTest.java`
- `Comment.java` (entity)
- `pom.xml` (added dependency)
- `Request.java` (added one to many relationship)

⚠️ Please review `Request.java` mapping to comments and vice versa change carefully—it may need further testing.