### PR TITLE
Backend support for Healthcare & Wellbeing help requests

### DIFF
--- a/src/main/java/org/sfa/request/dto/ReqAddInfoDTO.java
+++ b/src/main/java/org/sfa/request/dto/ReqAddInfoDTO.java
@@ -1,0 +1,23 @@
+package org.sfa.request.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReqAddInfoDTO {
+
+    @NotBlank(message = "Additional information field ID cannot be blank")
+    private String fieldId;
+
+    private String fieldValue;
+
+    private List<String> selectedItems;
+}

--- a/src/main/java/org/sfa/request/dto/RequestDTO.java
+++ b/src/main/java/org/sfa/request/dto/RequestDTO.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -61,4 +63,8 @@ public class RequestDTO {
 
     @NotNull(message = "Request for cannot be null")
     private RequestForDTO requestFor;
+
+    @Valid
+    @ToString.Exclude
+    private List<ReqAddInfoDTO> additionalFields;
 }

--- a/src/main/java/org/sfa/request/model/entity/ReqAddInfo.java
+++ b/src/main/java/org/sfa/request/model/entity/ReqAddInfo.java
@@ -1,0 +1,40 @@
+package org.sfa.request.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "req_add_info", schema = "virginia_dev_saayam_rdbms")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReqAddInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "info_id")
+    private Integer infoId;
+
+    @Column(name = "req_id", nullable = false)
+    private String requestId;
+
+    @Column(name = "field_id", nullable = false)
+    private String fieldId;
+
+    @Column(name = "item_id")
+    private String itemId;
+
+    @Column(name = "field_value")
+    private String fieldValue;
+}

--- a/src/main/java/org/sfa/request/repository/ReqAddInfoRepository.java
+++ b/src/main/java/org/sfa/request/repository/ReqAddInfoRepository.java
@@ -1,0 +1,7 @@
+package org.sfa.request.repository;
+
+import org.sfa.request.model.entity.ReqAddInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReqAddInfoRepository extends JpaRepository<ReqAddInfo, Integer> {
+}

--- a/src/main/java/org/sfa/request/service/impl/MetadataServiceImpl.java
+++ b/src/main/java/org/sfa/request/service/impl/MetadataServiceImpl.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 @Service
 public class MetadataServiceImpl implements MetadataService {
 
+    private static final String ACTIVE_STATUS = "active";
+
     private final ReqAddInfoMetadataRepository metadataRepo;
     private final ListItemMetadataRepository listItemRepo;
 
@@ -28,14 +30,16 @@ public class MetadataServiceImpl implements MetadataService {
 
     @Override
     public List<ReqAddInfoMetadataDto> getMetadataByCategoryId(String catId) {
-        List<ReqAddInfoMetadata> fields = metadataRepo.findByCatId(catId);
+        List<ReqAddInfoMetadata> fields = metadataRepo.findByCatIdAndStatus(catId, ACTIVE_STATUS);
         fields.sort(Comparator.comparing(ReqAddInfoMetadata::getFieldId, new NaturalOrderComparator()));
         return fields.stream().map(this::mapToDtoNoItems).collect(Collectors.toList());
     }
 
     @Override
     public List<ReqAddInfoMetadataTreeDto> getMetadataCategoryTree() {
-        List<ReqAddInfoMetadata> all = metadataRepo.findAll();
+        List<ReqAddInfoMetadata> all = new ArrayList<>(metadataRepo.findAll().stream()
+                .filter(metadata -> ACTIVE_STATUS.equalsIgnoreCase(metadata.getStatus()))
+                .toList());
 
         all.sort(Comparator
                 .comparing(ReqAddInfoMetadata::getCatId, new NaturalOrderComparator())
@@ -62,7 +66,7 @@ public class MetadataServiceImpl implements MetadataService {
 
     @Override
     public ReqAddInfoMetadataTreeDto getMetadataFormByCategoryId(String catId) {
-        List<ReqAddInfoMetadata> fields = metadataRepo.findByCatId(catId);
+        List<ReqAddInfoMetadata> fields = metadataRepo.findByCatIdAndStatus(catId, ACTIVE_STATUS);
 
         fields.sort(Comparator.comparing(ReqAddInfoMetadata::getFieldId, new NaturalOrderComparator()));
 

--- a/src/main/java/org/sfa/request/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/sfa/request/service/impl/RequestServiceImpl.java
@@ -2,6 +2,7 @@ package org.sfa.request.service.impl;
 
 import org.sfa.request.constant.SaayamStatusCode;
 import org.sfa.request.dto.GuestDetailsDTO;
+import org.sfa.request.dto.ReqAddInfoDTO;
 import org.sfa.request.response.PagedResponse;
 import org.sfa.request.dto.RequestDTO;
 import org.sfa.request.exception.types.ConflictException;
@@ -24,9 +25,17 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * ClassName: RequestServiceImpl
@@ -72,6 +81,9 @@ public class RequestServiceImpl implements RequestService {
     private final RequestPriorityRepository requestPriorityRepository;
     private final RequestTypeRepository requestTypeRepository;
     private final HelpCategoryRepository helpCategoryRepository;
+    private final ReqAddInfoMetadataRepository reqAddInfoMetadataRepository;
+    private final ListItemMetadataRepository listItemMetadataRepository;
+    private final ReqAddInfoRepository reqAddInfoRepository;
     private final RequestForRepository requestForRepository;
     private final MessageSource messageSource;
 
@@ -86,6 +98,10 @@ public class RequestServiceImpl implements RequestService {
         RequestFor requestFor = getRequestFor(requestDTO.getRequestFor().getRequestForId(), locale);
         RequestStatus requestStatus = getRequestStatus(RequestStatusEnum.CREATED.getId(), locale);
         RequestIsLeadVolunteer isLeadVolunteer = getIsLeadVolunteer(requestDTO.getIsLeadVolunteer(), locale);
+        List<ReqAddInfo> additionalInfo = validateAdditionalInfo(
+                requestDTO.getAdditionalFields(),
+                helpCategory.getCatId()
+        );
 
         Request request = buildRequest(
                 requesterId,
@@ -98,6 +114,8 @@ public class RequestServiceImpl implements RequestService {
                 isLeadVolunteer
         );
         Request savedRequest = requestRepository.save(request);
+
+        saveAdditionalInfo(savedRequest.getRequestId(), additionalInfo);
 
         if (requestFor.getRequestForId() == 1 && requestDTO.getGuestDetails() != null) {
             GuestDetailsDTO guestDTO = requestDTO.getGuestDetails();
@@ -356,5 +374,157 @@ public class RequestServiceImpl implements RequestService {
                 .ifPresent(volId -> request.setIsLeadVolunteer(getIsLeadVolunteer(volId, locale)));
 
         Optional.ofNullable(requestDTO.getServicedAt()).ifPresent(request::setServicedAt);
+    }
+
+    private List<ReqAddInfo> validateAdditionalInfo(List<ReqAddInfoDTO> submittedFields, String categoryId) {
+        if (submittedFields == null || submittedFields.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> submittedFieldIds = new HashSet<>();
+        List<ReqAddInfo> validatedRows = new ArrayList<>();
+
+        for (ReqAddInfoDTO submittedField : submittedFields) {
+            if (submittedField == null || submittedField.getFieldId() == null
+                    || submittedField.getFieldId().isBlank()) {
+                throw new InvalidRequestException("Additional information field ID is required");
+            }
+
+            String fieldId = submittedField.getFieldId().trim();
+            if (!submittedFieldIds.add(fieldId)) {
+                throw new InvalidRequestException("Duplicate additional information field: " + fieldId);
+            }
+
+            ReqAddInfoMetadata metadata = reqAddInfoMetadataRepository.findById(fieldId)
+                    .orElseThrow(() -> new InvalidRequestException(
+                            "Unknown additional information field: " + fieldId
+                    ));
+
+            if (!categoryId.equals(metadata.getCatId())) {
+                throw new InvalidRequestException(
+                        "Additional information field " + fieldId + " does not belong to category " + categoryId
+                );
+            }
+
+            if (!"active".equalsIgnoreCase(metadata.getStatus())) {
+                throw new InvalidRequestException("Additional information field is inactive: " + fieldId);
+            }
+
+            validateFieldValue(metadata, submittedField, validatedRows);
+        }
+
+        return validatedRows;
+    }
+
+    private void validateFieldValue(ReqAddInfoMetadata metadata, ReqAddInfoDTO submittedField,
+                                    List<ReqAddInfo> validatedRows) {
+        String fieldId = metadata.getFieldId();
+        String fieldType = metadata.getFieldType() == null
+                ? ""
+                : metadata.getFieldType().trim().toLowerCase(Locale.ROOT);
+
+        if ("list".equals(fieldType)) {
+            validateListField(fieldId, submittedField, validatedRows);
+            return;
+        }
+
+        if (submittedField.getSelectedItems() != null) {
+            throw new InvalidRequestException("Field " + fieldId + " does not accept list-item selections");
+        }
+
+        String fieldValue = submittedField.getFieldValue();
+        if (fieldValue == null || fieldValue.isBlank()) {
+            throw new InvalidRequestException("A value is required for field " + fieldId);
+        }
+
+        String normalizedValue = fieldValue.trim();
+        validateScalarValue(fieldId, fieldType, normalizedValue);
+        validatedRows.add(ReqAddInfo.builder()
+                .fieldId(fieldId)
+                .fieldValue(normalizedValue)
+                .build());
+    }
+
+    private void validateListField(String fieldId, ReqAddInfoDTO submittedField,
+                                   List<ReqAddInfo> validatedRows) {
+        if (submittedField.getFieldValue() != null) {
+            throw new InvalidRequestException("List field " + fieldId + " does not accept a scalar value");
+        }
+
+        List<String> selectedItems = submittedField.getSelectedItems();
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            throw new InvalidRequestException("At least one list item is required for field " + fieldId);
+        }
+
+        Set<String> allowedItemIds = new HashSet<>();
+        for (ListItemMetadata item : listItemMetadataRepository.findByFieldId(fieldId)) {
+            allowedItemIds.add(item.getItemId());
+        }
+
+        Set<String> selectedItemIds = new HashSet<>();
+        for (String selectedItem : selectedItems) {
+            if (selectedItem == null || selectedItem.isBlank()) {
+                throw new InvalidRequestException("List item ID is required for field " + fieldId);
+            }
+
+            String itemId = selectedItem.trim();
+            if (!selectedItemIds.add(itemId)) {
+                throw new InvalidRequestException("Duplicate list item " + itemId + " for field " + fieldId);
+            }
+            if (!allowedItemIds.contains(itemId)) {
+                throw new InvalidRequestException("Invalid list item " + itemId + " for field " + fieldId);
+            }
+
+            validatedRows.add(ReqAddInfo.builder()
+                    .fieldId(fieldId)
+                    .itemId(itemId)
+                    .build());
+        }
+    }
+
+    private void validateScalarValue(String fieldId, String fieldType, String fieldValue) {
+        try {
+            switch (fieldType) {
+                case "textbox" -> {
+                    // Any non-blank text is valid.
+                }
+                case "integer" -> Integer.parseInt(fieldValue);
+                case "checkbox" -> {
+                    if (!"true".equalsIgnoreCase(fieldValue) && !"false".equalsIgnoreCase(fieldValue)) {
+                        throw new IllegalArgumentException();
+                    }
+                }
+                case "time" -> LocalTime.parse(fieldValue);
+                case "date&time" -> validateDateTime(fieldValue);
+                case "currency" -> new BigDecimal(fieldValue);
+                default -> throw new InvalidRequestException(
+                        "Unsupported metadata field type " + fieldType + " for field " + fieldId
+                );
+            }
+        } catch (InvalidRequestException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw new InvalidRequestException(
+                    "Invalid " + fieldType + " value for field " + fieldId,
+                    exception
+            );
+        }
+    }
+
+    private void validateDateTime(String fieldValue) {
+        try {
+            OffsetDateTime.parse(fieldValue);
+        } catch (RuntimeException offsetDateTimeException) {
+            LocalDateTime.parse(fieldValue);
+        }
+    }
+
+    private void saveAdditionalInfo(String requestId, List<ReqAddInfo> additionalInfo) {
+        if (additionalInfo.isEmpty()) {
+            return;
+        }
+
+        additionalInfo.forEach(info -> info.setRequestId(requestId));
+        reqAddInfoRepository.saveAll(additionalInfo);
     }
 }

--- a/src/test/java/org/sfa/request/service/impl/MetadataServiceImplTest.java
+++ b/src/test/java/org/sfa/request/service/impl/MetadataServiceImplTest.java
@@ -1,0 +1,113 @@
+package org.sfa.request.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sfa.request.dto.ReqAddInfoDTO;
+import org.sfa.request.dto.ReqAddInfoMetadataTreeDto;
+import org.sfa.request.dto.RequestDTO;
+import org.sfa.request.model.entity.ReqAddInfoMetadata;
+import org.sfa.request.repository.ListItemMetadataRepository;
+import org.sfa.request.repository.ReqAddInfoMetadataRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataServiceImplTest {
+
+    @Mock
+    private ReqAddInfoMetadataRepository metadataRepository;
+
+    @Mock
+    private ListItemMetadataRepository listItemMetadataRepository;
+
+    @InjectMocks
+    private MetadataServiceImpl metadataService;
+
+    @Test
+    void getMetadataFormByCategoryId_returnsActiveFieldsOnly() {
+        ReqAddInfoMetadata activeMetadata = ReqAddInfoMetadata.builder()
+                .fieldId("5.2.A")
+                .fieldNameKey("DELIVERY_TYPE")
+                .fieldType("list")
+                .status("active")
+                .catId("5.2")
+                .build();
+        when(metadataRepository.findByCatIdAndStatus("5.2", "active"))
+                .thenReturn(new ArrayList<>(List.of(activeMetadata)));
+        when(listItemMetadataRepository.findByFieldIdIn(List.of("5.2.A")))
+                .thenReturn(new ArrayList<>());
+
+        ReqAddInfoMetadataTreeDto result = metadataService.getMetadataFormByCategoryId("5.2");
+
+        assertEquals("5.2", result.getCatId());
+        assertEquals(1, result.getFields().size());
+        assertEquals("5.2.A", result.getFields().get(0).getFieldId());
+        assertEquals("active", result.getFields().get(0).getStatus());
+        verify(metadataRepository, never()).findByCatId("5.2");
+    }
+
+    @Test
+    void getMetadataByCategoryId_usesActiveOnlyQuery() {
+        ReqAddInfoMetadata activeMetadata = metadata("5.2.A", "active", "5.2");
+        when(metadataRepository.findByCatIdAndStatus("5.2", "active"))
+                .thenReturn(new ArrayList<>(List.of(activeMetadata)));
+
+        var result = metadataService.getMetadataByCategoryId("5.2");
+
+        assertEquals(1, result.size());
+        assertEquals("5.2.A", result.get(0).getFieldId());
+        verify(metadataRepository, never()).findByCatId("5.2");
+    }
+
+    @Test
+    void getMetadataCategoryTree_filtersInactiveFields() {
+        ReqAddInfoMetadata activeMetadata = metadata("5.2.A", "active", "5.2");
+        ReqAddInfoMetadata inactiveMetadata = metadata("5.2.B", "inactive", "5.2");
+        when(metadataRepository.findAll())
+                .thenReturn(new ArrayList<>(List.of(activeMetadata, inactiveMetadata)));
+
+        var result = metadataService.getMetadataCategoryTree();
+
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getFields().size());
+        assertEquals("5.2.A", result.get(0).getFields().get(0).getFieldId());
+    }
+
+    @Test
+    void requestDtoToString_excludesAdditionalFieldsContent() {
+        RequestDTO request = new RequestDTO();
+        request.setAdditionalFields(List.of(
+                ReqAddInfoDTO.builder()
+                        .fieldId("5.2.SECRET_FIELD")
+                        .fieldValue("SECRET_SCALAR_VALUE")
+                        .selectedItems(List.of("5.2.SECRET_ITEM"))
+                        .build()
+        ));
+
+        String requestText = request.toString();
+
+        assertFalse(requestText.contains("5.2.SECRET_FIELD"));
+        assertFalse(requestText.contains("SECRET_SCALAR_VALUE"));
+        assertFalse(requestText.contains("5.2.SECRET_ITEM"));
+    }
+
+    private ReqAddInfoMetadata metadata(String fieldId, String status, String categoryId) {
+        return ReqAddInfoMetadata.builder()
+                .fieldId(fieldId)
+                .fieldNameKey(fieldId)
+                .fieldType("list")
+                .status(status)
+                .catId(categoryId)
+                .build();
+    }
+}

--- a/src/test/java/org/sfa/request/service/impl/RequestServiceImplAdditionalInfoTest.java
+++ b/src/test/java/org/sfa/request/service/impl/RequestServiceImplAdditionalInfoTest.java
@@ -1,0 +1,466 @@
+package org.sfa.request.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sfa.request.dto.HelpCategoryDto;
+import org.sfa.request.dto.ReqAddInfoDTO;
+import org.sfa.request.dto.RequestDTO;
+import org.sfa.request.dto.RequestForDTO;
+import org.sfa.request.dto.RequestPriorityDTO;
+import org.sfa.request.dto.RequestStatusDTO;
+import org.sfa.request.dto.RequestTypeDTO;
+import org.sfa.request.exception.types.InvalidRequestException;
+import org.sfa.request.model.entity.HelpCategory;
+import org.sfa.request.model.entity.ListItemMetadata;
+import org.sfa.request.model.entity.ReqAddInfo;
+import org.sfa.request.model.entity.ReqAddInfoMetadata;
+import org.sfa.request.model.entity.Request;
+import org.sfa.request.model.entity.RequestFor;
+import org.sfa.request.model.entity.RequestIsLeadVolunteer;
+import org.sfa.request.model.entity.RequestPriority;
+import org.sfa.request.model.entity.RequestStatus;
+import org.sfa.request.model.entity.RequestType;
+import org.sfa.request.repository.HelpCategoryRepository;
+import org.sfa.request.repository.ListItemMetadataRepository;
+import org.sfa.request.repository.ReqAddInfoMetadataRepository;
+import org.sfa.request.repository.ReqAddInfoRepository;
+import org.sfa.request.repository.RequestForRepository;
+import org.sfa.request.repository.RequestGuestDetailsRepository;
+import org.sfa.request.repository.RequestIsLeadVolunteerRepository;
+import org.sfa.request.repository.RequestPriorityRepository;
+import org.sfa.request.repository.RequestRepository;
+import org.sfa.request.repository.RequestStatusRepository;
+import org.sfa.request.repository.RequestTypeRepository;
+import org.sfa.request.service.api.RequestService;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestServiceImplAdditionalInfoTest {
+
+    private static final Locale LOCALE = Locale.US;
+    private static final String CATEGORY_ID = "5.2";
+
+    @Mock
+    private RequestRepository requestRepository;
+    @Mock
+    private RequestGuestDetailsRepository requestGuestDetailsRepository;
+    @Mock
+    private RequestStatusRepository requestStatusRepository;
+    @Mock
+    private RequestIsLeadVolunteerRepository requestIsLeadVolunteerRepository;
+    @Mock
+    private RequestPriorityRepository requestPriorityRepository;
+    @Mock
+    private RequestTypeRepository requestTypeRepository;
+    @Mock
+    private HelpCategoryRepository helpCategoryRepository;
+    @Mock
+    private ReqAddInfoMetadataRepository reqAddInfoMetadataRepository;
+    @Mock
+    private ListItemMetadataRepository listItemMetadataRepository;
+    @Mock
+    private ReqAddInfoRepository reqAddInfoRepository;
+    @Mock
+    private RequestForRepository requestForRepository;
+    @Mock
+    private MessageSource messageSource;
+
+    @InjectMocks
+    private RequestServiceImpl requestService;
+
+    @BeforeEach
+    void setUp() {
+        RequestPriority priority = new RequestPriority();
+        priority.setPriorityId(1);
+        when(requestPriorityRepository.findById(1)).thenReturn(Optional.of(priority));
+
+        RequestType type = new RequestType();
+        type.setRequestTypeId(1);
+        when(requestTypeRepository.findById(1)).thenReturn(Optional.of(type));
+
+        when(helpCategoryRepository.findById(CATEGORY_ID)).thenReturn(Optional.of(
+                HelpCategory.builder().catId(CATEGORY_ID).catName("MEDICINE_DELIVERY").build()
+        ));
+
+        RequestFor requestFor = new RequestFor();
+        requestFor.setRequestForId(0);
+        when(requestForRepository.findById(0)).thenReturn(Optional.of(requestFor));
+
+        RequestStatus status = new RequestStatus();
+        status.setRequestStatusId(1);
+        when(requestStatusRepository.findById(anyInt())).thenReturn(Optional.of(status));
+
+        RequestIsLeadVolunteer isLeadVolunteer = new RequestIsLeadVolunteer();
+        isLeadVolunteer.setReqIsleadId(0);
+        when(requestIsLeadVolunteerRepository.findById(0)).thenReturn(Optional.of(isLeadVolunteer));
+
+        lenient().when(requestRepository.save(any(Request.class))).thenAnswer(invocation -> {
+            Request request = invocation.getArgument(0);
+            request.setRequestId("REQ-00-000-000-0029");
+            return request;
+        });
+        lenient().when(messageSource.getMessage(anyString(), any(Object[].class), any(Locale.class)))
+                .thenReturn("created");
+    }
+
+    @Test
+    void createRequest_savesValidHealthcareAdditionalInfo() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                ReqAddInfoDTO.builder()
+                        .fieldId("5.2.A")
+                        .selectedItems(List.of("5.2.A.1"))
+                        .build(),
+                ReqAddInfoDTO.builder()
+                        .fieldId("5.2.E")
+                        .fieldValue("true")
+                        .build()
+        ));
+        when(reqAddInfoMetadataRepository.findById("5.2.A"))
+                .thenReturn(Optional.of(metadata("5.2.A", "list", "active", CATEGORY_ID)));
+        when(reqAddInfoMetadataRepository.findById("5.2.E"))
+                .thenReturn(Optional.of(metadata("5.2.E", "checkbox", "active", CATEGORY_ID)));
+        when(listItemMetadataRepository.findByFieldId("5.2.A"))
+                .thenReturn(List.of(listItem("5.2.A.1", "5.2.A")));
+
+        requestService.createRequest("SID-29", request, LOCALE);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ReqAddInfo>> captor = ArgumentCaptor.forClass(List.class);
+        verify(reqAddInfoRepository).saveAll(captor.capture());
+        List<ReqAddInfo> savedRows = captor.getValue();
+        assertEquals(2, savedRows.size());
+        assertEquals("REQ-00-000-000-0029", savedRows.get(0).getRequestId());
+        assertEquals("5.2.A", savedRows.get(0).getFieldId());
+        assertEquals("5.2.A.1", savedRows.get(0).getItemId());
+        assertNull(savedRows.get(0).getFieldValue());
+        assertEquals("5.2.E", savedRows.get(1).getFieldId());
+        assertNull(savedRows.get(1).getItemId());
+        assertEquals("true", savedRows.get(1).getFieldValue());
+    }
+
+    @Test
+    void createRequest_acceptsMissingAdditionalInfoForBackwardCompatibility() {
+        requestService.createRequest("SID-29", requestWithAdditionalFields(null), LOCALE);
+
+        verify(reqAddInfoRepository, never()).saveAll(any());
+        verify(requestRepository).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsUnknownField() {
+        RequestDTO request = requestWithAdditionalFields(List.of(scalarField("5.2.UNKNOWN", "value")));
+        when(reqAddInfoMetadataRepository.findById("5.2.UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsCrossCategoryField() {
+        RequestDTO request = requestWithAdditionalFields(List.of(scalarField("5.3.C", "value")));
+        when(reqAddInfoMetadataRepository.findById("5.3.C"))
+                .thenReturn(Optional.of(metadata("5.3.C", "textbox", "active", "5.3")));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsInactiveMetadata() {
+        RequestDTO request = requestWithAdditionalFields(List.of(scalarField("5.2.E", "true")));
+        when(reqAddInfoMetadataRepository.findById("5.2.E"))
+                .thenReturn(Optional.of(metadata("5.2.E", "checkbox", "inactive", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsFieldTypeMismatch() {
+        RequestDTO request = requestWithAdditionalFields(List.of(scalarField("5.2.E", "not-a-boolean")));
+        when(reqAddInfoMetadataRepository.findById("5.2.E"))
+                .thenReturn(Optional.of(metadata("5.2.E", "checkbox", "active", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsEmptySelectedItemsForScalarField() {
+        assertRejectedScalarPayload(
+                ReqAddInfoDTO.builder().fieldId("5.2.E").fieldValue("true").selectedItems(List.of()).build(),
+                "checkbox"
+        );
+    }
+
+    @Test
+    void createRequest_rejectsNonEmptySelectedItemsForScalarField() {
+        assertRejectedScalarPayload(
+                ReqAddInfoDTO.builder().fieldId("5.2.E").fieldValue("true")
+                        .selectedItems(List.of("5.2.E.1")).build(),
+                "checkbox"
+        );
+    }
+
+    @Test
+    void createRequest_rejectsNullScalarValue() {
+        assertRejectedScalarPayload(scalarField("5.2.E", null), "checkbox");
+    }
+
+    @Test
+    void createRequest_rejectsBlankScalarValue() {
+        assertRejectedScalarPayload(scalarField("5.2.E", "   "), "checkbox");
+    }
+
+    @Test
+    void createRequest_rejectsBlankScalarValueForListField() {
+        assertRejectedListPayload(
+                ReqAddInfoDTO.builder().fieldId("5.2.A").fieldValue("")
+                        .selectedItems(List.of("5.2.A.1")).build()
+        );
+    }
+
+    @Test
+    void createRequest_rejectsNonBlankScalarValueForListField() {
+        assertRejectedListPayload(
+                ReqAddInfoDTO.builder().fieldId("5.2.A").fieldValue("display value")
+                        .selectedItems(List.of("5.2.A.1")).build()
+        );
+    }
+
+    @Test
+    void createRequest_rejectsNullSelectedItemsForListField() {
+        assertRejectedListPayload(ReqAddInfoDTO.builder().fieldId("5.2.A").build());
+    }
+
+    @Test
+    void createRequest_rejectsEmptySelectedItemsForListField() {
+        assertRejectedListPayload(
+                ReqAddInfoDTO.builder().fieldId("5.2.A").selectedItems(List.of()).build()
+        );
+    }
+
+    @Test
+    void createRequest_rejectsMalformedInteger() {
+        assertRejectedScalarPayload(scalarField("5.2.INTEGER", "12.5"), "integer");
+    }
+
+    @Test
+    void createRequest_rejectsMalformedCurrency() {
+        assertRejectedScalarPayload(scalarField("5.2.CURRENCY", "twelve dollars"), "currency");
+    }
+
+    @Test
+    void createRequest_rejectsMalformedTime() {
+        assertRejectedScalarPayload(scalarField("5.2.TIME", "25:61"), "time");
+    }
+
+    @Test
+    void createRequest_rejectsMalformedDateTime() {
+        assertRejectedScalarPayload(scalarField("5.2.DATE_TIME", "not-a-date"), "date&time");
+    }
+
+    @Test
+    void createRequest_rejectsNullMetadataFieldType() {
+        assertRejectedScalarPayload(scalarField("5.2.NULL_TYPE", "value"), null);
+    }
+
+    @Test
+    void createRequest_rejectsUnsupportedMetadataFieldType() {
+        assertRejectedScalarPayload(scalarField("5.2.UNSUPPORTED", "value"), "unsupported");
+    }
+
+    @Test
+    void createRequest_rejectsNullSelectedItem() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                ReqAddInfoDTO.builder().fieldId("5.2.A")
+                        .selectedItems(Collections.singletonList(null)).build()
+        ));
+        when(reqAddInfoMetadataRepository.findById("5.2.A"))
+                .thenReturn(Optional.of(metadata("5.2.A", "list", "active", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsBlankFieldId() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                ReqAddInfoDTO.builder().fieldId("   ").fieldValue("value").build()
+        ));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsInvalidListItem() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                ReqAddInfoDTO.builder().fieldId("5.2.A").selectedItems(List.of("5.2.A.99")).build()
+        ));
+        when(reqAddInfoMetadataRepository.findById("5.2.A"))
+                .thenReturn(Optional.of(metadata("5.2.A", "list", "active", CATEGORY_ID)));
+        when(listItemMetadataRepository.findByFieldId("5.2.A"))
+                .thenReturn(List.of(listItem("5.2.A.1", "5.2.A")));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsDuplicateFieldIds() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                scalarField("5.2.E", "true"),
+                scalarField("5.2.E", "false")
+        ));
+        when(reqAddInfoMetadataRepository.findById("5.2.E"))
+                .thenReturn(Optional.of(metadata("5.2.E", "checkbox", "active", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rejectsDuplicateSelectedItems() {
+        RequestDTO request = requestWithAdditionalFields(List.of(
+                ReqAddInfoDTO.builder()
+                        .fieldId("5.2.A")
+                        .selectedItems(List.of("5.2.A.1", "5.2.A.1"))
+                        .build()
+        ));
+        when(reqAddInfoMetadataRepository.findById("5.2.A"))
+                .thenReturn(Optional.of(metadata("5.2.A", "list", "active", CATEGORY_ID)));
+        when(listItemMetadataRepository.findByFieldId("5.2.A"))
+                .thenReturn(List.of(listItem("5.2.A.1", "5.2.A")));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    @Test
+    void createRequest_rollsBackWhenAdditionalInfoSaveFails() {
+        RequestDTO request = requestWithAdditionalFields(List.of(scalarField("5.2.E", "true")));
+        when(reqAddInfoMetadataRepository.findById("5.2.E"))
+                .thenReturn(Optional.of(metadata("5.2.E", "checkbox", "active", CATEGORY_ID)));
+        when(reqAddInfoRepository.saveAll(any())).thenThrow(new RuntimeException("database failure"));
+
+        PlatformTransactionManager transactionManager = org.mockito.Mockito.mock(PlatformTransactionManager.class);
+        TransactionStatus transactionStatus = org.mockito.Mockito.mock(TransactionStatus.class);
+        when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+
+        TransactionInterceptor transactionInterceptor = new TransactionInterceptor(
+                transactionManager,
+                new AnnotationTransactionAttributeSource()
+        );
+        ProxyFactory proxyFactory = new ProxyFactory(requestService);
+        proxyFactory.addAdvice(transactionInterceptor);
+        RequestService transactionalService = (RequestService) proxyFactory.getProxy();
+
+        assertThrows(RuntimeException.class,
+                () -> transactionalService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository).save(any(Request.class));
+        verify(transactionManager).rollback(transactionStatus);
+    }
+
+    private RequestDTO requestWithAdditionalFields(List<ReqAddInfoDTO> additionalFields) {
+        RequestDTO request = new RequestDTO();
+        request.setRequesterId("SID-29");
+        request.setRequestSubject("Medicine delivery");
+        request.setRequestDescription("Need non-clinical assistance");
+        request.setIsLeadVolunteer(0);
+
+        RequestStatusDTO status = new RequestStatusDTO();
+        status.setRequestStatusId(1);
+        request.setRequestStatus(status);
+
+        RequestPriorityDTO priority = new RequestPriorityDTO();
+        priority.setRequestPriorityId(1);
+        request.setRequestPriority(priority);
+
+        RequestTypeDTO type = new RequestTypeDTO();
+        type.setRequestTypeId(1);
+        request.setRequestType(type);
+
+        HelpCategoryDto category = new HelpCategoryDto();
+        category.setCatId(CATEGORY_ID);
+        request.setHelpCategory(category);
+
+        RequestForDTO requestFor = new RequestForDTO();
+        requestFor.setRequestForId(0);
+        request.setRequestFor(requestFor);
+        request.setAdditionalFields(additionalFields);
+        return request;
+    }
+
+    private ReqAddInfoDTO scalarField(String fieldId, String value) {
+        return ReqAddInfoDTO.builder().fieldId(fieldId).fieldValue(value).build();
+    }
+
+    private void assertRejectedScalarPayload(ReqAddInfoDTO submittedField, String fieldType) {
+        RequestDTO request = requestWithAdditionalFields(List.of(submittedField));
+        when(reqAddInfoMetadataRepository.findById(submittedField.getFieldId()))
+                .thenReturn(Optional.of(metadata(submittedField.getFieldId(), fieldType, "active", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    private void assertRejectedListPayload(ReqAddInfoDTO submittedField) {
+        RequestDTO request = requestWithAdditionalFields(List.of(submittedField));
+        when(reqAddInfoMetadataRepository.findById(submittedField.getFieldId()))
+                .thenReturn(Optional.of(metadata(submittedField.getFieldId(), "list", "active", CATEGORY_ID)));
+
+        assertThrows(InvalidRequestException.class,
+                () -> requestService.createRequest("SID-29", request, LOCALE));
+        verify(requestRepository, never()).save(any(Request.class));
+    }
+
+    private ReqAddInfoMetadata metadata(String fieldId, String fieldType, String status, String categoryId) {
+        return ReqAddInfoMetadata.builder()
+                .fieldId(fieldId)
+                .fieldType(fieldType)
+                .status(status)
+                .catId(categoryId)
+                .build();
+    }
+
+    private ListItemMetadata listItem(String itemId, String fieldId) {
+        return ListItemMetadata.builder().itemId(itemId).fieldId(fieldId).build();
+    }
+}


### PR DESCRIPTION
## Summary

Implements backend support for structured Healthcare & Wellbeing request metadata for BA Issue #29.

## Changes

- Added structured Request Additional Info payload support.
- Added `ReqAddInfo` persistence using the existing `req_add_info` table design.
- Added metadata validation for:
  - category ownership
  - active status
  - unknown fields
  - duplicate fields
  - duplicate selections
  - scalar/list shape validation
  - supported field types
  - list-item ownership
- Persisted Request Additional Info within the existing request transaction.
- Updated metadata responses to return active fields only.
- Prevented Healthcare answers from appearing in request DTO logs.
- Preserved backward compatibility for requests without additional fields.

## Tests

- 30 focused tests passed.
- Maven compile passed.
- Maven package with inherited tests skipped passed.
- `git diff --check` passed.

## Known external blockers

- Deployed Category 5 database rows and list metadata were not verifiable from this repository.
- Deployed `req_add_info` primary-key column must be confirmed as `info_id` versus `id`.
- Metadata currently has no mandatory-field flag, so omitted required fields cannot be enforced generically.
- The inherited full test suite on `dev` currently references stale classes and constructors and does not compile independently of this change.

## Scope

No frontend, database seed, category data, timezone, retry, attachment, controller, or unrelated request behavior was changed.

Reference:
https://github.com/saayam-for-all/ba/issues/29